### PR TITLE
Fix role requirement for deleting order items to allow customers

### DIFF
--- a/backend/src/routes/order.routes.ts
+++ b/backend/src/routes/order.routes.ts
@@ -10,7 +10,7 @@ router.get("/admin", requireAuth, requireRole("admin"), OrderController.adminGet
 router.get("/search", requireAuth, requireRole("admin"), OrderController.adminOrderSEarchController);
 router.post("/checkout", requireAuth, requireRole("customer"), OrderController.createOrderController);
 router.get("/:orderId", requireAuth, OrderController.getOrderByIdController);
-router.delete("/:orderId/items/:itemId", requireAuth, requireRole("admin"), OrderController.cancelOrderItemController);
+router.delete("/:orderId/items/:itemId", requireAuth, requireRole("customer"), OrderController.cancelOrderItemController);
 router.patch("/:orderId/cancel", requireAuth, requireRole("customer"), OrderController.cancelOrderController);
 router.patch("/:orderId/status", requireAuth, requireRole("admin"), OrderController.updateOrderStatusController);
 router.post("/buy-now", requireAuth, requireRole("customer"), OrderController.buyNowController);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Customers now have the ability to independently cancel individual items from their active orders without requiring administrative assistance. Previously, only administrators could perform this action. This enhancement significantly improves the order management experience, granting customers greater control and flexibility over their purchases while minimizing support requests for routine order modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->