### PR TITLE
feat: add server route for server status and integrate with main API

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import filterRouter from "./routes/filter.route";
 import webhookRouter from "./routes/webhook.route";
 import mailRouter from "./routes/testemail.route";
 import assistantRouter from "./routes/assistant.route";
+import serverRouter from "./routes/server.route";
 import helmet from "helmet";
 import { startUpCleanScheduler } from "./corn/cleanup.queue";
 import "./corn/user/cleanup.worker"
@@ -59,6 +60,7 @@ if (config.app.env === "production") {
 }
 connectDB();
 
+app.use("/api", serverRouter)
 app.use("/api/users", userRouter);
 app.use("/api/products", productRouter);
 app.use("/api/cart", cartRouter);

--- a/backend/src/routes/server.route.ts
+++ b/backend/src/routes/server.route.ts
@@ -1,0 +1,13 @@
+import express, {Request, Response} from "express"
+const router = express.Router()
+
+const PORT = process.env.PORT || 4400;
+
+router.get("/server", (req: Request, res: Response) => {
+    res.json({
+        pid: process.pid,
+        port: PORT
+    })
+})
+
+export default router;

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,9 +1,7 @@
 import { MetadataRoute } from "next";
 
-
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     let productUrls: MetadataRoute.Sitemap = [];
-
     try {
         const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/products/?limit=500&page=1`, {
             next: { revalidate: 3600 },
@@ -24,5 +22,4 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         { url: `${process.env.NEXT_PUBLIC_SITE_URL}/product`, changeFrequency: "daily", priority: 0.9 },
         ...productUrls,
     ];
-
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint that returns basic server information, including the current process ID and active port.
  * The API routes are now available under the `/api` path.
* **Style**
  * Updated sitemap formatting with no change to behavior or output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->